### PR TITLE
Add Shields in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,80 @@
-# Book Reviewer
+# BookReviewer
 
-A web application for reviewing and rating books, built with Quarkus (backend) and Vue.js + Quasar (frontend).
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/YerayBrito/BookReviewer)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![Contributors](https://img.shields.io/github/contributors/YerayBrito/BookReviewer?style=flat-square)](https://github.com/YerayBrito/BookReviewer/graphs/contributors)
+[![Last Commit](https://img.shields.io/github/last-commit/YerayBrito/BookReviewer)](https://github.com/YerayBrito/BookReviewer/commits/develop)
+[![Open Issues](https://img.shields.io/github/issues/YerayBrito/BookReviewer?style=flat-square)](https://github.com/YerayBrito/BookReviewer/issues)
 
-## Quick Start
+A modern web application to review and rate books, built with **Quarkus** (backend) and **Vue.js + Quasar** (frontend).
+
+
+## ✨ Features
+
+- 📚 **Book Catalog:** Browse a curated list of books with cover images, authors, and descriptions.
+- 🔍 **Book Details:** View detailed information for each book, including average rating and all user reviews.
+- 📝 **Review System:** Write your own reviews and rate books from 1 to 5 stars.
+- 👤 **User Profiles:** Each user has a profile page showing their review history and ratings.
+- 📱 **Responsive Design:** Enjoy a seamless experience on desktop, tablet, and mobile devices.
+
+
+## 🛠️ Technologies Used
+
+- **Backend:** [Quarkus](https://quarkus.io/) (Java 21)
+- **Frontend:** [Vue.js](https://vuejs.org/) + [Quasar Framework](https://quasar.dev/)
+- **Database:** H2 (development), MariaDB (production/tests)
+- **API:** RESTful endpoints
+- **Testing:** JUnit (backend), Cypress (frontend)
+
+
+## 🚀 Getting Started
 
 ### Prerequisites
+
 - Java 21 or higher
 - Node.js 18 or higher
-- MariaDB (optional, H2 is used by default in development)
+- MariaDB (optional, H2 is used by default for development)
 
-### Environment Setup
+### Installation
 
 #### Backend
+
 ```bash
 cd backend
-# Copy environment example and configure if needed
 cp env.example .env
-# Run with default configuration
 ./mvnw quarkus:dev
 ```
-Available at: `http://localhost:8080` (configurable via environment variables)
+Backend will be running at: [http://localhost:8080](http://localhost:8080)
 
 #### Frontend
+
 ```bash
 cd frontend
-# Copy environment example and configure if needed
 cp env.example .env
 npm install
 npm run dev
 ```
-Available at: `http://localhost:5173` (configurable via environment variables)
+Frontend will be running at: [http://localhost:5173](http://localhost:5173)
 
-## Configuration
+
+## ⚙️ Configuration
 
 ### Environment Variables
 
-#### Backend (.env)
+#### Backend (`.env`)
 - `SERVER_PORT` - Server port (default: 8080)
 - `DEV_SERVER_PORT` - Development server port (default: 8080)
 - `TEST_SERVER_PORT` - Test server port (default: 8081)
 - `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD` - Database configuration
 - `CORS_ORIGINS` - CORS allowed origins
 
-#### Frontend (.env)
+#### Frontend (`.env`)
 - `VITE_DEV_SERVER_PORT` - Development server port (default: 5173)
 - `VITE_API_BASE_URL` - Backend API URL (default: http://localhost:8080/api)
 - `VITE_APP_TITLE` - Application title
 
-### Database Configuration
-- **Development**: H2 in-memory database (default)
-- **Production**: MariaDB (configure via environment variables)
-- **Tests**: MariaDB with separate database
+### Database
 
-## Features
-- Browse book catalog
-- View book details and reviews
-- Write and rate book reviews
-- User profiles with review history
-
-## API Endpoints
-- Books: `/api/books`
-- Reviews: `/api/reviews`
-- Users: `/api/users` 
+- **Development:** H2 in-memory database (default)
+- **Production:** MariaDB (configure via environment variables)
+- **Tests:** MariaDB with a separate database


### PR DESCRIPTION
Add Shields.io badges and DeepWiki link to README
This pull request adds several badges to the top of the main README file to improve project visibility and quick access to key information:
A static badge linking to the project's DeepWiki page.
Dynamic Shields.io badges for:
License (MIT)
Contributors
Last commit (develop branch)
Open issues
Each badge includes a direct link to the relevant section or resource.